### PR TITLE
add user playlist selection

### DIFF
--- a/app/src/androidTest/java/com/lambdasoup/watchlater/ui/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/lambdasoup/watchlater/ui/AddActivityTest.kt
@@ -84,6 +84,8 @@ class AddActivityTest : WatchLaterActivityTest() {
                 account = null,
                 permissionNeeded = null,
                 tokenRetried = false,
+                playlistSelection = null,
+                targetPlaylist = null,
         ))
         events.clear()
         whenever(vm.model).thenReturn(model)
@@ -192,17 +194,6 @@ class AddActivityTest : WatchLaterActivityTest() {
     }
 
     @Test
-    fun should_show_default_error() {
-        model.postValue(model.value!!.copy(
-                videoInfo = VideoInfo.Error(YoutubeRepository.ErrorType.AlreadyInPlaylist),
-        ))
-
-        onView(withId(R.id.reason_title)).check(matches(withText(R.string.video_error_title)))
-        val expectedText = getString(R.string.could_not_load, YoutubeRepository.ErrorType.AlreadyInPlaylist.toString())
-        onView(withId(R.id.reason)).check(matches(withText(expectedText)))
-    }
-
-    @Test
     fun should_show_watch_buttons_on_default_error() {
         model.postValue(model.value!!.copy(
                 videoInfo = VideoInfo.Error(YoutubeRepository.ErrorType.Other),
@@ -234,16 +225,6 @@ class AddActivityTest : WatchLaterActivityTest() {
         intended(Matchers.allOf(
                 hasData(intent.data),
                 toPackage("com.google.android.youtube")))
-    }
-
-    @Test
-    fun should_show_add_video_result_error_already_in_playlist() {
-        vm.model.postValue(
-                vm.model.value!!.copy(videoAdd = VideoAdd.Error(VideoAdd.ErrorType.YoutubeAlreadyInPlaylist))
-        )
-
-        val expectedText = getString(R.string.could_not_add, getString(R.string.error_already_in_playlist))
-        onView(withId(R.id.add_result)).check(matches(withText(expectedText)))
     }
 
     @Test

--- a/app/src/main/java/com/lambdasoup/watchlater/ui/PlaylistView.kt
+++ b/app/src/main/java/com/lambdasoup/watchlater/ui/PlaylistView.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015 - 2021
+ *
+ * Maximilian Hille <mh@lambdasoup.com>
+ * Juliane Lehmann <jl@lambdasoup.com>
+ *
+ * This file is part of Watch Later.
+ *
+ * Watch Later is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Watch Later is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Watch Later.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.lambdasoup.watchlater.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.lifecycle.Observer
+import com.lambdasoup.watchlater.R
+import com.lambdasoup.watchlater.data.YoutubeRepository.Playlists.Playlist
+
+class PlaylistView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr), View.OnClickListener, Observer<Playlist?> {
+
+    var listener: Listener? = null
+
+    private val label: TextView
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.view_playlist, this)
+        findViewById<View>(R.id.view_playlist_set).setOnClickListener(this)
+        label = findViewById(R.id.view_playlist_label)
+    }
+
+    override fun onClick(view: View) {
+        listener?.onChangePlaylist()
+    }
+
+    override fun onChanged(playlist: Playlist?) {
+        if (playlist == null) {
+            label.setText(R.string.playlist_empty)
+            return
+        }
+        label.text = playlist.snippet.title
+    }
+
+    interface Listener {
+        fun onChangePlaylist()
+    }
+}

--- a/app/src/main/java/com/lambdasoup/watchlater/ui/ResultView.kt
+++ b/app/src/main/java/com/lambdasoup/watchlater/ui/ResultView.kt
@@ -51,8 +51,7 @@ class ResultView @JvmOverloads constructor(
         val errorStr: String = when (errorType) {
             VideoAdd.ErrorType.NoAccount -> resources.getString(R.string.error_no_account)
             VideoAdd.ErrorType.NoPermission -> resources.getString(R.string.error_no_permission)
-            VideoAdd.ErrorType.YoutubeAlreadyInPlaylist -> resources.getString(R.string.error_already_in_playlist)
-            VideoAdd.ErrorType.OperationUnsupported -> resources.getString(R.string.error_operation_unsupported)
+            VideoAdd.ErrorType.NoPlaylistSelected -> resources.getString(R.string.error_no_playlist)
             else -> resources.getString(R.string.error_general, errorType.name)
         }
         setResult(true, resources.getString(R.string.could_not_add, errorStr))

--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -1,23 +1,23 @@
 <!--
-  ~   Copyright (c) 2015 - 2017
+  ~ Copyright (c) 2015 - 2021
   ~
-  ~   Maximilian Hille <mh@lambdasoup.com>
-  ~   Juliane Lehmann <jl@lambdasoup.com>
+  ~ Maximilian Hille <mh@lambdasoup.com>
+  ~ Juliane Lehmann <jl@lambdasoup.com>
   ~
-  ~   This file is part of Watch Later.
+  ~ This file is part of Watch Later.
   ~
-  ~   Watch Later is free software: you can redistribute it and/or modify
-  ~   it under the terms of the GNU General Public License as published by
-  ~   the Free Software Foundation, either version 3 of the License, or
-  ~   (at your option) any later version.
+  ~ Watch Later is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
   ~
-  ~   Watch Later is distributed in the hope that it will be useful,
-  ~   but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~   GNU General Public License for more details.
+  ~ Watch Later is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
   ~
-  ~   You should have received a copy of the GNU General Public License
-  ~   along with Watch Later.  If not, see <http://www.gnu.org/licenses/>.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Watch Later.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -53,6 +53,13 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:layout_marginStart="@dimen/activity_horizontal_margin" />
+
+        <com.lambdasoup.watchlater.ui.PlaylistView
+            android:id="@+id/add_playlist"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin" />
 
         <com.lambdasoup.watchlater.ui.PermissionsView
             android:id="@+id/add_permissions"

--- a/app/src/main/res/layout/view_playlist.xml
+++ b/app/src/main/res/layout/view_playlist.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2015 - 2021
+  ~
+  ~ Maximilian Hille <mh@lambdasoup.com>
+  ~ Juliane Lehmann <jl@lambdasoup.com>
+  ~
+  ~ This file is part of Watch Later.
+  ~
+  ~ Watch Later is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Watch Later is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Watch Later.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:layout_height="wrap_content"
+    tools:layout_width="match_parent"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <TextView
+        android:id="@+id/view_playlist_label"
+        style="@style/TextAppearance.AppCompat.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        tools:text="@string/playlist_empty" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/view_playlist_set"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/account_set" />
+
+</merge>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,15 +21,12 @@
   -->
 
 <resources>
-
     <string name="app_name">Später ansehen</string>
     <string name="asset_prefix">de</string>
     <string name="title_activity_about">Über</string>
     <string name="menu_about">Über</string>
-    <string name="success_added_video">Video zu \'Später Ansehen\'-Liste hinzugefügt</string>
-    <string name="error_already_in_playlist">Video ist bereits in \'Später Ansehen\'-Liste</string>
+    <string name="success_added_video">Video zu Liste hinzugefügt</string>
     <string name="error_video_not_found">Video nicht gefunden</string>
-    <string name="error_operation_unsupported">YouTube hat das Hinzufügen zu \"Später Ansehen\" Listen deaktiviert. Ein App-Update welches reguläre Listen nutzt ist in Vorbereitung.</string>
     <string name="choose_account">Konto auswählen</string>
     <string name="error_no_account">Kein Konto ausgewählt</string>
     <string name="error_youtube_player_missing">Kann YouYube-App nicht starten. Ist die App installiert?</string>
@@ -49,6 +46,7 @@
     <string name="could_not_add">Konnte Video nicht hinzufügen: %s</string>
     <string name="could_not_load">Konnte Vorschau nicht laden (%s)</string>
     <string name="account_empty">Kein Konto ausgewählt</string>
+    <string name="playlist_empty">Keine Liste ausgewählt</string>
     <string name="account_set">ändern</string>
     <string name="add_permissions_rationale">Die App wird nicht auf Deine Kontakte zugreifen. Die Berechtigung ist notwending, um mit Deinem YouTube-Konto zu kommunizieren.</string>
     <string name="launcher_youtube_action_title">Bitte einstellen</string>
@@ -60,5 +58,9 @@
     <string name="action_watchnow">Jetzt ansehen</string>
     <string name="action_watchlater">Später ansehen</string>
     <string name="needs_youtube_permissions">Bitte YouTube-Zugriff erlauben</string>
-
+    <string name="error_no_playlist">Keine Liste ausgewählt</string>
+    <string name="playlist_selection_message">Du hast noch keine Wiedergabelisten in deinem YouTube-Account. Bitte lege erst eine an.</string>
+    <string name="playlist_selection_title">Liste auswählen</string>
+    <string name="playlist_selection_edit">Listen editieren</string>
+    <string name="playlist_selection_create">Liste erstellen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,19 +22,11 @@
 
 <resources>
     <string name="asset_prefix">default</string>
-
     <string name="app_name">Watch Later</string>
-
     <string name="title_activity_about">About</string>
-
     <string name="menu_about">About</string>
-
-    <string name="success_added_video">Video successfully added to your Watch Later list</string>
-
-    <string name="error_already_in_playlist">Video is already in your Watch Later list</string>
+    <string name="success_added_video">Video successfully added to your playlist</string>
     <string name="error_video_not_found">Video not found</string>
-    <string name="error_operation_unsupported">YouTube shut down the ability to insert videos into Watch Later playlists. An app update to use regular playlists instead is in preparation.</string>
-
     <string name="choose_account">Choose account</string>
     <string name="error_no_account">No account set</string>
     <string name="error_youtube_player_missing">Cannot launch the YouTube app: it is probably not installed on your device.</string>
@@ -51,10 +43,12 @@
     <string name="add_permissions_description">This app needs permissions to function.</string>
     <string name="add_permissions_grant">grant</string>
     <string name="error_no_permission">Missing permissions</string>
+    <string name="error_no_playlist">No playlist selected</string>
     <string name="could_not_add">Could not add video: %s</string>
     <string name="could_not_load">Could not load video preview (%s)</string>
     <string name="account_empty">No account selected</string>
     <string name="account_set">Change</string>
+    <string name="playlist_empty">No playlist selected</string>
     <string name="add_permissions_rationale">Note that this app will not actually access any of your contacts. This permission is needed for communicating with your YouTube account.</string>
     <string name="launcher_youtube_action_title">Action required</string>
     <string name="launcher_youtube_action_text">Your system is configured to open YouTube links with the YouTube app by default. Open the YouTube settings and make sure that \'Open Defaults\' is set to \'Ask every time\'.</string>
@@ -65,5 +59,8 @@
     <string name="action_watchnow">Watch now</string>
     <string name="action_watchlater">Watch later</string>
     <string name="needs_youtube_permissions">Please confirm YouTube permission request</string>
-
+    <string name="playlist_selection_message">You don\'t have any playlists in your YouTube account yet. Please create one in the YouTube app first.</string>
+    <string name="playlist_selection_title">Select Playlist</string>
+    <string name="playlist_selection_edit">Edit playlists</string>
+    <string name="playlist_selection_create">Create playlist</string>
 </resources>

--- a/tea/src/main/java/com/lambdasoup/tea/Cmd.kt
+++ b/tea/src/main/java/com/lambdasoup/tea/Cmd.kt
@@ -34,13 +34,14 @@ sealed class Cmd<Msg> {
     internal data class Task<Msg>(
             val task: () -> Msg,
     ) : Cmd<Msg>()
-    
+
     internal data class Batch<Msg>(
             val cmds: Set<Cmd<Msg>>
     ) : Cmd<Msg>()
 
     internal class None<Msg> : Cmd<Msg>()
 
+    @Suppress("unused")
     companion object {
         fun <Msg> none(): Cmd<Msg> = None()
         fun <Msg> batch(vararg cmds: Cmd<Msg>): Cmd<Msg> = Batch(setOf(*cmds))
@@ -49,11 +50,17 @@ sealed class Cmd<Msg> {
         fun <Msg, T> task(f: () -> (T)): ((T) -> Msg) -> Cmd<Msg> = { g ->
             Task { g(f()) }
         }
-        fun <Msg, R, T> task(f: (R) -> (T)): (R, (T) -> Msg) -> Cmd<Msg> = { r,g ->
-            Task { g(f(r)) }
+
+        fun <Msg, A, T> task(f: (A) -> (T)): (A, (T) -> Msg) -> Cmd<Msg> = { a, g ->
+            Task { g(f(a)) }
         }
-        fun <Msg, R, S, T> task(f: (R, S) -> (T)): (R, S, (T) -> Msg) -> Cmd<Msg> = { r, s,g ->
-            Task { g(f(r, s)) }
+
+        fun <Msg, A, B, T> task(f: (A, B) -> (T)): (A, B, (T) -> Msg) -> Cmd<Msg> = { a, b, g ->
+            Task { g(f(a, b)) }
+        }
+
+        fun <Msg, A, B, C, T> task(f: (A, B, C) -> (T)): (A, B, C, (T) -> Msg) -> Cmd<Msg> = { a, b, c, g ->
+            Task { g(f(a, b, c)) }
         }
     }
 }


### PR DESCRIPTION
The changes in this PR add user playlist selection to have a way of this app still making sense after the API shut down (see https://github.com/lambdasoup/watchlater/issues/53).

This will obviously make the app worse but for now there is no other solution. Whatever YouTube plans to do with the current Watch Later functionality is unknown. Maybe there will be a similar new functionality on YouTube at some point and even an API for it...