### PR TITLE
use user auth for video info

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,5 @@ image:https://raw.githubusercontent.com/lambdasoup/watchlater/master/web_hi_res_
 
 Watch Later is an Android app which lets you add videos to your Watch Later list instead of watching them now.
 
-== YouTube API key
-This app needs a YouYube API key. For convenience, the file resource file `values/apikey.xml` is in .gitignore to put the key in there.
-
 == License
 This app is licensed under GPL3+

--- a/app/src/androidTest/java/com/lambdasoup/watchlater/ui/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/lambdasoup/watchlater/ui/AddActivityTest.kt
@@ -176,7 +176,7 @@ class AddActivityTest : WatchLaterActivityTest() {
     @Test
     fun should_show_network_error() {
         model.postValue(model.value!!.copy(
-                videoInfo = VideoInfo.Error(YoutubeRepository.ErrorType.Network),
+                videoInfo = VideoInfo.Error(VideoInfo.ErrorType.Youtube(YoutubeRepository.ErrorType.Network)),
         ))
 
         onView(withId(R.id.reason_title)).check(matches(withText(R.string.video_error_title)))
@@ -186,7 +186,7 @@ class AddActivityTest : WatchLaterActivityTest() {
     @Test
     fun should_show_video_not_found_error() {
         model.postValue(model.value!!.copy(
-                videoInfo = VideoInfo.Error(YoutubeRepository.ErrorType.VideoNotFound),
+                videoInfo = VideoInfo.Error(VideoInfo.ErrorType.Youtube(YoutubeRepository.ErrorType.VideoNotFound)),
         ))
 
         onView(withId(R.id.reason_title)).check(matches(withText(R.string.video_error_title)))
@@ -196,7 +196,7 @@ class AddActivityTest : WatchLaterActivityTest() {
     @Test
     fun should_show_watch_buttons_on_default_error() {
         model.postValue(model.value!!.copy(
-                videoInfo = VideoInfo.Error(YoutubeRepository.ErrorType.Other),
+                videoInfo = VideoInfo.Error(VideoInfo.ErrorType.Youtube(YoutubeRepository.ErrorType.Other)),
         ))
 
         onView(withId(R.id.action_watchnow)).check(matches(isDisplayed()))

--- a/app/src/main/java/com/lambdasoup/watchlater/data/YoutubeRepository.kt
+++ b/app/src/main/java/com/lambdasoup/watchlater/data/YoutubeRepository.kt
@@ -26,7 +26,6 @@ import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.preference.PreferenceManager
 import com.lambdasoup.watchlater.BuildConfig
-import com.lambdasoup.watchlater.R
 import com.lambdasoup.watchlater.data.YoutubeRepository.PlaylistItem.Snippet.ResourceId
 import com.lambdasoup.watchlater.data.YoutubeRepository.Playlists.Playlist
 import com.squareup.moshi.JsonClass
@@ -46,7 +45,6 @@ class YoutubeRepository(context: Context) {
     private val prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     private val retrofit: Retrofit
-    private val apiKey: String
     private val api: YoutubeApi
 
     private val _targetPlaylist = object : LiveData<Playlist?>(), SharedPreferences.OnSharedPreferenceChangeListener {
@@ -96,7 +94,6 @@ class YoutubeRepository(context: Context) {
             loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
             httpClient.networkInterceptors().add(loggingInterceptor)
         }
-        apiKey = context.getString(R.string.youtube_api_key)
 
         val retrofitBuilder = Retrofit.Builder()
                 .baseUrl(YOUTUBE_ENDPOINT)
@@ -116,10 +113,11 @@ class YoutubeRepository(context: Context) {
                 .apply()
     }
 
-    fun getVideoInfo(videoId: String): VideoInfoResult {
+    fun getVideoInfo(videoId: String, token: String): VideoInfoResult {
+        val auth = "Bearer $token"
         val response: Response<Videos>
         try {
-            response = api.listVideos(videoId, apiKey).execute()
+            response = api.listVideos(videoId, auth).execute()
         } catch (e: IOException) {
             return VideoInfoResult.Error(ErrorType.Network)
         }
@@ -211,7 +209,8 @@ class YoutubeRepository(context: Context) {
 
         @GET("videos?part=snippet,contentDetails&maxResults=1")
         fun listVideos(
-                @Query("id") id: String, @Query("key") apiKey: String,
+                @Query("id") id: String,
+                @Header("Authorization") auth: String,
         ): Call<Videos>
 
         @GET("playlists?part=snippet&mine=true")

--- a/app/src/main/java/com/lambdasoup/watchlater/ui/VideoView.kt
+++ b/app/src/main/java/com/lambdasoup/watchlater/ui/VideoView.kt
@@ -33,7 +33,7 @@ import android.widget.TextView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.lambdasoup.watchlater.R
-import com.lambdasoup.watchlater.data.YoutubeRepository.ErrorType
+import com.lambdasoup.watchlater.data.YoutubeRepository
 import com.lambdasoup.watchlater.data.YoutubeRepository.Videos
 import com.lambdasoup.watchlater.util.formatDuration
 import com.lambdasoup.watchlater.viewmodel.AddViewModel
@@ -86,9 +86,13 @@ class VideoView @JvmOverloads constructor(
         show(error)
         val reason: TextView = error.findViewById(R.id.reason)
         when (errorType) {
-            ErrorType.Network -> reason.setText(R.string.error_network)
-            ErrorType.VideoNotFound -> reason.setText(R.string.error_video_not_found)
-            else -> reason.text = resources.getString(R.string.could_not_load, errorType.toString())
+            is ErrorType.Youtube -> when (errorType.error) {
+                YoutubeRepository.ErrorType.Network -> reason.setText(R.string.error_network)
+                YoutubeRepository.ErrorType.VideoNotFound -> reason.setText(R.string.error_video_not_found)
+                else -> reason.text = resources.getString(R.string.could_not_load, errorType.toString())
+            }
+            is ErrorType.InvalidVideoId -> reason.setText(R.string.error_invalid_video_id)
+            is ErrorType.NoAccount -> reason.setText(R.string.error_video_info_no_account)
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -67,4 +67,6 @@
     <string name="playlist_selection_title">Liste auswählen</string>
     <string name="playlist_selection_edit">Listen editieren</string>
     <string name="playlist_selection_create">Liste erstellen</string>
+    <string name="error_invalid_video_id">Link enthält ungültige Video ID</string>
+    <string name="error_video_info_no_account">Video Info kann nur mit ausgewähltem Konto angezeigt werden</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,6 @@
     <string name="playlist_selection_title">Select Playlist</string>
     <string name="playlist_selection_edit">Edit playlists</string>
     <string name="playlist_selection_create">Create playlist</string>
+    <string name="error_invalid_video_id">Link has invalid video ID</string>
+    <string name="error_video_info_no_account">Video info can not be displayed without account</string>
 </resources>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,5 @@
 steps:
 
-# get YouTube API key from storage
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: copy_api_key
-  args: ['-q', 'cp', 'gs://watchlater-build-config/apikey.xml', 'app/src/main/res/values/']
-
 # build the project
 - name: 'mreichelt/android:31'
   id: build
@@ -13,8 +8,6 @@ steps:
     - 'TERM=dumb'
     - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dkotlin.incremental=false"'
     - 'BRANCH_NAME=$BRANCH_NAME'
-  waitFor:
-    - copy_api_key
 
 # save APK
 - name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
Since Google Play increased the "bad level" of having the YouTube/GCP API key in the app, I looked into ways of solving that issue more cleanly. Using the user account for getting the VideoInfo let's us work without the API key at all so this seems to be a very good solution.

The only problem we have now is that we can not show the VideoInfo _initially_ (basically only the first time the user tries the app). So for this first use case we show a new error message and we also retrigger the VideoInfo fetch once the account is added.

This also means that quota worries are now a thing of the past. We will keep the current key alive though and only kill it once the API usage in our GCP goes low.