### PR TITLE
UI tests for LauncherActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,8 @@ android {
         targetSdkVersion 32
         versionCode version_major * 10000 + version_minor * 100 + version_patch * 1
         versionName "$version_major.$version_minor.$version_patch"
-        // testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunner "io.cucumber.android.runner.CucumberAndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+//        testInstrumentationRunner "io.cucumber.android.runner.CucumberAndroidJUnitRunner"
     }
 
     buildTypes {
@@ -118,6 +118,10 @@ dependencies {
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     androidTestImplementation project(':tea-testing-support')
 
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.2.1"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:1.2.1"
+
+    androidTestImplementation project(':tea-testing-support')
     androidTestImplementation 'androidx.test:core:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'

--- a/app/src/androidTest/java/com/lambdasoup/watchlater/Util.kt
+++ b/app/src/androidTest/java/com/lambdasoup/watchlater/Util.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 - 2022
+ *
+ * Maximilian Hille <mh@lambdasoup.com>
+ * Juliane Lehmann <jl@lambdasoup.com>
+ *
+ * This file is part of Watch Later.
+ *
+ * Watch Later is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Watch Later is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Watch Later.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.lambdasoup.watchlater
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+
+fun AndroidComposeTestRule<*, *>.onNodeWithTextRes(
+    @StringRes textResId: Int, substring: Boolean = false,
+    ignoreCase: Boolean = false, useUnmergedTree: Boolean = false
+): SemanticsNodeInteraction {
+    val text = ApplicationProvider.getApplicationContext<Context>().resources.getString(textResId)
+    return onNodeWithText(
+        text = text,
+        substring = substring,
+        ignoreCase = ignoreCase,
+        useUnmergedTree = useUnmergedTree
+    )
+}

--- a/app/src/androidTest/java/com/lambdasoup/watchlater/test/CucumberTest.kt
+++ b/app/src/androidTest/java/com/lambdasoup/watchlater/test/CucumberTest.kt
@@ -82,6 +82,8 @@ class CucumberTest {
 
     private val server = MockWebServer()
 
+    private val idlingResource = TeaIdlingResource()
+
     @Before
     fun before() {
         server.start(port = 8080)
@@ -106,7 +108,7 @@ class CucumberTest {
             mock()
         )
 
-        IdlingRegistry.getInstance().register(TeaIdlingResource())
+        IdlingRegistry.getInstance().register(idlingResource.espressoIdlingResource)
     }
 
     @After

--- a/app/src/androidTest/java/com/lambdasoup/watchlater/test/CucumberTest.kt
+++ b/app/src/androidTest/java/com/lambdasoup/watchlater/test/CucumberTest.kt
@@ -113,6 +113,7 @@ class CucumberTest {
 
     @After
     fun after() {
+        IdlingRegistry.getInstance().unregister(idlingResource.espressoIdlingResource)
         Intents.release()
         server.shutdown()
     }

--- a/app/src/androidTest/java/com/lambdasoup/watchlater/test/LauncherActivityTest.kt
+++ b/app/src/androidTest/java/com/lambdasoup/watchlater/test/LauncherActivityTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2015 - 2022
+ *
+ * Maximilian Hille <mh@lambdasoup.com>
+ * Juliane Lehmann <jl@lambdasoup.com>
+ *
+ * This file is part of Watch Later.
+ *
+ * Watch Later is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Watch Later is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Watch Later.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("ClassName")
+
+package com.lambdasoup.watchlater.test
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.content.pm.verify.domain.DomainVerificationManager
+import android.content.pm.verify.domain.DomainVerificationUserState
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import com.lambdasoup.tea_junit4.TeaIdlingResource
+import com.lambdasoup.watchlater.R
+import com.lambdasoup.watchlater.onNodeWithTextRes
+import com.lambdasoup.watchlater.ui.LauncherActivity
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.hamcrest.Matchers
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class Launcher_try_demo_link_Test : LauncherActivityTest(
+    isWatchLaterDefault = true,
+    isHostnameVerificationComplete = true
+) {
+    @Test
+    fun try_demo_link() {
+        clickDemoButton()
+        assertVideoOpened()
+    }
+}
+
+class Launcher_needs_default_Test : LauncherActivityTest(
+    isWatchLaterDefault = false,
+    isHostnameVerificationComplete = true
+) {
+    @Test
+    fun needs_default() {
+        assertSetupInstructionsVisible()
+    }
+}
+
+class Launcher_needs_verification_Test : LauncherActivityTest(
+    isWatchLaterDefault = true,
+    isHostnameVerificationComplete = false
+) {
+    @Test
+    fun needs_verification() {
+        assertSetupInstructionsVisible()
+    }
+}
+
+class Launcher_setup_complete_Test : LauncherActivityTest(
+    isWatchLaterDefault = true,
+    isHostnameVerificationComplete = true,
+) {
+    @Test
+    fun setup_complete() {
+        assertSetupInstructionsInvisible()
+    }
+}
+
+class LauncherActivityEnvironmentRule(
+    private val activityRule: AndroidComposeTestRule<*, *>,
+    private val isWatchLaterDefault: Boolean,
+    private val isHostnameVerificationComplete: Boolean
+) : TestRule {
+    private val idlingResource = TeaIdlingResource()
+    private val packageManager: PackageManager = com.lambdasoup.watchlater.packageManager
+    private val domainVerificationManager: DomainVerificationManager =
+        com.lambdasoup.watchlater.domainVerificationManager
+    private val server = MockWebServer()
+
+
+    private fun before() {
+        setupMocking()
+
+        val resolveInfo = if (isWatchLaterDefault) {
+            ResolveInfo().apply {
+                activityInfo = ActivityInfo().apply {
+                    name = "com.lambdasoup.watchlater.ui.AddActivity"
+                }
+            }
+        } else {
+            null
+        }
+        whenever(packageManager.resolveActivity(any(), eq(PackageManager.MATCH_DEFAULT_ONLY)))
+            .thenReturn(resolveInfo)
+
+        val state: DomainVerificationUserState = mock()
+        val stateLookupResult = if (isHostnameVerificationComplete) {
+            mapOf(
+                "test.domain.1" to DomainVerificationUserState.DOMAIN_STATE_VERIFIED,
+                "test.domain.2" to DomainVerificationUserState.DOMAIN_STATE_VERIFIED,
+                "test.domain.3" to DomainVerificationUserState.DOMAIN_STATE_VERIFIED,
+            )
+        } else {
+            mapOf(
+                "test.domain.1" to DomainVerificationUserState.DOMAIN_STATE_VERIFIED,
+                "test.domain.2" to DomainVerificationUserState.DOMAIN_STATE_NONE,
+                "test.domain.3" to DomainVerificationUserState.DOMAIN_STATE_VERIFIED,
+            )
+        }
+        whenever(state.hostToStateMap).thenReturn(stateLookupResult)
+        whenever(domainVerificationManager.getDomainVerificationUserState(any()))
+            .thenReturn(state)
+    }
+
+    private fun setupMocking() {
+        server.start(port = 8080)
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest) =
+                when (request.path) {
+                    "/videos?part=snippet,contentDetails&maxResults=1&id=dGFSjKuJfrI" ->
+                        MockResponse()
+                            .setResponseCode(200)
+                            .setBody(CucumberTest.VIDEO_INFO_JSON)
+                    else -> MockResponse()
+                        .setResponseCode(404)
+                        .setBody("unhandled path + ${request.path}")
+                }
+        }
+
+        Intents.init()
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, Intent()))
+
+        whenever(domainVerificationManager.getDomainVerificationUserState(any())).thenReturn(
+            mock()
+        )
+
+        activityRule.registerIdlingResource(idlingResource.composeIdlingResource)
+    }
+
+    private fun after() {
+        activityRule.unregisterIdlingResource(idlingResource.composeIdlingResource)
+        Intents.release()
+        server.shutdown()
+    }
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            @Throws(Throwable::class)
+            override fun evaluate() {
+                before()
+                try {
+                    base.evaluate()
+                } finally {
+                    after()
+                }
+            }
+        }
+    }
+
+}
+
+abstract class LauncherActivityTest(
+    isWatchLaterDefault: Boolean,
+    isHostnameVerificationComplete: Boolean
+) {
+    @get:Rule(order = 1)
+    val activityRule = createAndroidComposeRule<LauncherActivity>()
+
+    @get:Rule(order = 0)
+    val environmentRule = LauncherActivityEnvironmentRule(
+        activityRule = activityRule,
+        isWatchLaterDefault = isWatchLaterDefault,
+        isHostnameVerificationComplete = isHostnameVerificationComplete
+    )
+
+    fun clickDemoButton() {
+        activityRule.onNodeWithTextRes(R.string.launcher_example_button, ignoreCase = true).performClick()
+    }
+
+    fun assertVideoOpened() {
+        Intents.intended(Matchers.allOf(IntentMatchers.hasData("https://www.youtube.com/watch?v=dGFSjKuJfrI")))
+    }
+
+    fun assertSetupInstructionsVisible() {
+        activityRule.onNodeWithTextRes(R.string.launcher_action_title).assertExists()
+    }
+
+    fun assertSetupInstructionsInvisible() {
+        activityRule.onNodeWithTextRes(R.string.launcher_action_title).assertDoesNotExist()
+    }
+}

--- a/tea/src/main/java/com/lambdasoup/tea/Tea.kt
+++ b/tea/src/main/java/com/lambdasoup/tea/Tea.kt
@@ -113,7 +113,7 @@ class Tea<Model, Msg>(
     companion object {
         /**
          * Overwrite before instantiating Tea to set a different engine. Only meant and useful for testing purposes
-         * (see tea-junit4).
+         * (see tea-testing-support).
          */
         var createEngine: () -> Engine = {
             DefaultEngine()


### PR DESCRIPTION
As we had discussed, this commit:
- deactivates the cucumber tests (so for now, AddActivity is without coverage)
- but leaves the setup in place
- ports the test scenarios for LauncherActivity to AndroidComposeTestRule-based abominations of inheritance