### PR TITLE
Fix "stuck" topbar in launcher on first run

### DIFF
--- a/app/src/main/java/com/lambdasoup/watchlater/ui/launcher/LauncherScreen.kt
+++ b/app/src/main/java/com/lambdasoup/watchlater/ui/launcher/LauncherScreen.kt
@@ -92,6 +92,11 @@ fun LauncherScreen(
                 }
             }
         }
+        val scrollState = rememberScrollState()
+        if (scrollState.maxValue == Int.MAX_VALUE || scrollState.maxValue == 0) {
+            // nestedScrollConnection won't learn when scrolling becomes impossible, so we check here
+            topBarOffsetHeightPx.value = 0f
+        }
 
         // Not using Scaffold here, because it has opinions on where the topBar is that aren't interested in the
         // offset due to scrolling.
@@ -100,7 +105,6 @@ fun LauncherScreen(
                 .fillMaxSize()
                 .nestedScroll(nestedScrollConnection),
         ) {
-            val scrollState = rememberScrollState()
             Column(
                 modifier = Modifier
                     .verticalScroll(scrollState)
@@ -125,8 +129,7 @@ fun LauncherScreen(
                 modifier = Modifier
                     .height(topBarHeight)
                     .offset {
-                        IntOffset(x = 0,
-                                  y = topBarOffsetHeightPx.value.roundToInt())
+                        IntOffset(x = 0, y = topBarOffsetHeightPx.value.roundToInt())
                     },
                 title = { Text(text = stringResource(id = R.string.app_name)) },
                 actions = {


### PR DESCRIPTION
More precisely: when not all setup is complete, and so there's long and thus on most devices scrollable content in the launcher screen, and user scrolls down, then fixes the intent receiver situation, then returns to the launcher screen, the setup cards disappear, scrolling is not necessary anymore and the top bar stays disappeard and won't come back (because there's no scrolling anymore).

Not so anymore.